### PR TITLE
correctly register multiple plugins, pass plugin options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,51 @@
-#hapi-test
+# hapi-test
 Test hapi plugins with chaining method calls and assertions.
 
 [![Build Status](https://travis-ci.org/klokoy/hapi-test.svg?branch=master)](https://travis-ci.org/klokoy/hapi-test)
 
-#Assertions
-###end(result)
+### Assertions
+
 Using the end method you can write your own assertions in anyway you want.
+
 ```javascript
 //chai assertions
-var hapi-test = require('hapi-test'),
+var hapiTest = require('hapi-test'),
     plugin = require('your-plugin'),
     assert = require('chai').assert;
 
-hapiTest({plugins: [plugin]})
+hapiTest({ plugins: [ plugin ] })
     .get('/persons')
-    .end(function(result) {
+    .end(function (result) {
         assert(result.statusCode === 200);
     });
 ```
 
-###Status code
+### Status code
 If you want to test status code you can simply assert the statusCode number
 
 ```javascript
-hapiTest({plugins: [plugin]})
+hapiTest({ plugins: [ plugin ] })
     .get('/persons')
     .assert(200)
 ```
 
-###headers
+### Headers
 To test a header value you can do an assert with header name as first parameter and header value as second. Works with strings.
 
 ```javascript
 //string
-hapiTest({plugins: [plugin]})
+hapiTest({plugins: [ plugin ] })
     .get('/person')
     .assert('connection', 'keep-alive');
 ```
 
-###Async testing
+## Async testing
 If you are using mocha you can pass in the done function to any assertion as last parameter.
 
 ```javascript
 
 it('should 200 on persons', function(done) {
-    hapiTest({plugins: [plugin]})
+    hapiTest({ plugins: [ plugin ] })
         .get('/person')
         .assert(200, done)
 });
@@ -55,18 +56,18 @@ Mocha also supports promises.
 ```javascript
 
 it('should 200 on persons', function() {
-    return hapiTest({plugins: [plugin]})
+    return hapiTest({ plugins: [ plugin ] })
         .get('/person')
         .assert(200)
 });
 ```
 
-###Keep instance of server to speed up tests
+## Keep instance of server to speed up tests
 If you have multiple tests on the same server / plugins you can create an instance of the server and use this in the constructor. This will speed up the tests as it does not need to create a new server and initialize the plugins for each test.
 
 ```javascript
-//example using mocha
-var hapi-test = require('hapi-test'),
+// example using mocha
+var hapiTest = require('hapi-test'),
     Hapi = require('Hapi'),
     plugin = require('your-plugin'),
     assert = require('chai').assert;
@@ -89,7 +90,7 @@ before(function (done) {
 });
 
 it('can now be used', function (done) {
-    hapiTest({server: server})
+    hapiTest({ server: server })
         .get('/person')
         .assert(200, done);
 });

--- a/src/hapiTest.js
+++ b/src/hapiTest.js
@@ -43,7 +43,8 @@ HapiTest.prototype._init = function(callback) {
             self.server.register({
                 name: 'plugin' + index,
                 version: '0.0.1',
-                register: plugin.register
+                register: plugin.register,
+                options: plugin.options
             }, function() {
                 if (index === self.plugins.length - 1) {
                     callback();

--- a/src/hapiTest.js
+++ b/src/hapiTest.js
@@ -39,18 +39,8 @@ HapiTest.prototype._init = function(callback) {
             self.options.before(self.server);
         }
 
-        self.plugins.forEach(function(plugin, index) {
-            self.server.register({
-                name: 'plugin' + index,
-                version: '0.0.1',
-                register: plugin.register,
-                options: plugin.options
-            }, function() {
-                if (index === self.plugins.length - 1) {
-                    callback();
-                }
-            });
-        });
+        self.server.register(self.plugins, callback)
+        
     } else {
         //If I have a server there is nothing to init
         callback();


### PR DESCRIPTION
Correct me if this is wrong, but currently it is not possible to pass options to plugin which makes testing difficult. This change fixes it in our projects.

From 
```
hapiTest([ plugin ])
```

we have now

```
hapiTest({ register: plugin, options: { ... } })
```

If the code is merged, please also update on npm. Thank you!