### PR TITLE
Make hapi-test compatible with @hapi/hapi v20.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
  sudo: false
  language: node_js
  node_js:
-   - "8"
+   - "12"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If you have multiple tests on the same server / plugins you can create an instan
 ```javascript
 // example using mocha
 var hapiTest = require('hapi-test'),
-    Hapi = require('Hapi'),
+    Hapi = require('@hapi/hapi'),
     plugin = require('your-plugin'),
     assert = require('chai').assert;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-test",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Test hapi plugins with chaining method calls and assertions",
   "main": "index.js",
   "repository": {
@@ -18,16 +18,16 @@
   "author": "Kim Lokøy",
   "license": "MIT",
   "dependencies": {
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.20"
   },
   "peerDependencies": {
-    "hapi": ">=17.0.0"
+    "@hapi/hapi": ">=20.0.0"
   },
   "devDependencies": {
-    "hapi": "^17.0.0",
-    "boom": "^7.1.1",
+    "@hapi/hapi": "^20.0.0",
+    "@hapi/boom": "^9.1.0",
+    "@hapi/cookie": "^11.0.1",
     "chai": "^4.1.2",
-    "hapi-auth-cookie": "^8.1.0",
     "mocha": "^5.0.0"
   }
 }

--- a/src/hapiTest.js
+++ b/src/hapiTest.js
@@ -1,225 +1,166 @@
-var Hapi = require('hapi'),
-    _ = require('lodash');
+const Hapi = require('@hapi/hapi');
+const _ = require('lodash');
 
+module.exports = options => new HapiTest(options);
 
-module.exports = function(options) {
-
-    return new HapiTest(options);
-};
-
-var HapiTest = function(options) {
-    var self = this;
-
-    if (options.server) {
-        self.server = options.server;
-    } else {
-        self.plugins = options.plugins;
-    }
-    //requests can be cleared
-    self.requests = [];
-    //setup can be kept between calls
-    self.setup = {};
-
-    self.options = options;
-
-    return self;
-};
-
-HapiTest.prototype._init = async function() {
-    if (this.server) return Promise.resolve();
-
-    var self = this;
-
-    //If I do not have a server create one
-    self.server = new Hapi.Server({
-        port: 8888
-    });
-
-    if (self.options && self.options.before) {
-        await self.options.before(self.server);
-    }
-
-    return self.plugins ? self.server.register(self.plugins.map(plugin => ({plugin}))) : Promise.resolve()
-}
-
-HapiTest.prototype.get = function(url, query) {
-
-    var request = {
-        options: {
-            method: 'get',
-            url: url
-        }
-    };
-
-    if (query) {
-        request.options.query = query;
-    }
-
-    this.requests.push(request);
-
-    return this;
-};
-
-HapiTest.prototype.delete = function(url) {
-
-    var request = {
-        options: {
-            method: 'delete',
-            url: url
-        }
-    };
-
-    this.requests.push(request);
-
-    return this;
-};
-
-HapiTest.prototype.post = function(url, payload) {
-
-    var request = {
-        options: {
-            method: 'post',
-            url: url,
-            payload: payload
-        }
-    };
-
-    this.requests.push(request);
-
-    return this;
-};
-
-HapiTest.prototype.put = function(url, payload) {
-
-    var request = {
-        options: {
-            method: 'put',
-            url: url,
-            payload: payload
-        }
-    };
-
-    this.requests.push(request);
-
-    return this;
-};
-
-HapiTest.prototype.patch = function(url, payload) {
-
-    var request = {
-        options: {
-            method: 'patch',
-            url: url,
-            payload: payload
-        }
-    };
-
-    this.requests.push(request);
-
-    return this;
-};
-
-HapiTest.prototype.assert = function(a, b, c) {
-    var self = this;
-
-    var request = _.last(this.requests);
-    if (!request.rejections) {
-        request.rejections = [];
-    }
-
-    if (_.isNumber(a)) {
-        request.rejections.push(function(res) {
-            if (res.statusCode === a) {
-                return false;
-            } else {
-                return 'the status code is: ' + res.statusCode + ' but should be: ' + a;
-            }
-        });
-    } else if (_.isString(a)) {
-        request.rejections.push(function (res) {
-            return !res.headers[a].match(new RegExp(b));
-        });
-    } else if (_.isFunction(a)) {
-        request.rejections.push(function(res) {
-            return !a(res);
-        });
-    }
-
-    return self;
-};
-
-//Support hapi-auth-cookie
-HapiTest.prototype.auth = function(user) {
-
-    this.credentials = user;
-    return this;
-
-};
-
-//Support any request headers
-HapiTest.prototype.setRequestHeader = function(header) {
-    this.requestHeader = header;
-    return this;
-};
-
-
-HapiTest.prototype.end = async function() {
-
-    var self = this;
-
-    await self._init();
-
-    //run all request, return result in callback for the last request
-    async function handleRequest(n) {
-        var request = self.requests[n];
-
-        var injectOptions = _.merge(request.options, self.setup, {headers: self.requestHeader});
-        if (self.credentials) {
-            injectOptions.credentials = self.credentials;
-        }
-
-        // todo: catch inject errors
-        const result = await self.server.inject(injectOptions);
-
-        //If rejections for this request has been registered run them and collect errs
-        if (request.rejections) {
-            request.rejections.forEach(function(rejection) {
-                var failed = rejection(result);
-
-                if (failed) {
-                    if (!request.errs) {
-                        request.errs = [];
-                    }
-                    request.errs.push(failed);
-                }
-            })
-        }
-
-        if (n === self.requests.length - 1) {
-            //If this is the last request settle the promise
-            if (request.errs) {
-                throw request.errs;
-            } else {
-                return result;
-            }
+class HapiTest {
+    constructor(options) {
+        if (options.server) {
+            this.server = options.server;
         } else {
-            return handleRequest(n + 1);
+            this.plugins = options.plugins;
         }
+        //requests can be cleared
+        this.requests = [];
+        //setup can be kept between calls
+        this.setup = {};
+
+        this.options = options;
     }
 
-    return handleRequest(0);
-};
+    async _init() {
+        if (this.server) return Promise.resolve();
 
-HapiTest.prototype.then = function (callbackSuccess, callbackError) {
-    return this.end().then(callbackSuccess, errors => callbackError(getFirstError(errors)));
-};
+        //If I do not have a server create one
+        this.server = new Hapi.Server({ port: 8888 });
 
-HapiTest.prototype.catch = function (callbackError) {
-    return this.end().catch(errors => callbackError(getFirstError(errors)));
+        if (this.options && this.options.before) {
+            await this.options.before(this.server);
+        }
+
+        return this.plugins ? this.server.register(this.plugins.map(plugin => ({
+            plugin
+        }))) : Promise.resolve()
+    }
+
+    get(url, query) {
+        const request = { options: { method: 'get', url } };
+        if (query) {
+            request.options.query = query;
+        }
+        this.requests.push(request);
+        return this;
+    }
+
+    delete(url) {
+        const request = { options: { method: 'delete', url } };
+        this.requests.push(request);
+        return this;
+    }
+
+    post(url, payload) {
+        const request = { options: { method: 'post', url, payload } };
+        this.requests.push(request);
+        return this;
+    }
+
+    put(url, payload) {
+        const request = { options: { method: 'put', url, payload } };
+        this.requests.push(request);
+        return this;
+    }
+
+    patch(url, payload) {
+        const request = { options: { method: 'patch', url, payload } };
+        this.requests.push(request);
+        return this;
+    }
+
+    assert(a, b) {
+        const request = _.last(this.requests);
+        if (!request.rejections) {
+            request.rejections = [];
+        }
+
+        if (_.isNumber(a)) {
+            request.rejections.push(res => {
+                if (res.statusCode === a) {
+                    return false;
+                } else {
+                    return 'the status code is: ' + res.statusCode + ' but should be: ' + a;
+                }
+            });
+        } else if (_.isString(a)) {
+            request.rejections.push(res => {
+                return !res.headers[a].match(new RegExp(b));
+            });
+        } else if (_.isFunction(a)) {
+            request.rejections.push(res => {
+                return !a(res);
+            });
+        }
+
+        return this;
+    }
+
+    auth(injectAuth) {
+        this.injectAuth = injectAuth;
+        return this;
+    }
+
+    //Support any request headers
+    setRequestHeader(header) {
+        this.requestHeader = header;
+        return this;
+    }
+
+    async end() {
+        await this._init();
+
+        //run all request, return result in callback for the last request
+        const handleRequest = async n => {
+            const request = this.requests[n];
+
+            const injectOptions = _.merge(request.options, this.setup, {
+                headers: this.requestHeader
+            });
+            if (this.injectAuth) {
+                injectOptions.auth = this.injectAuth;
+            }
+
+            // todo: catch inject errors
+            const result = await this.server.inject(injectOptions);
+
+            //If rejections for this request has been registered run them and collect errs
+            if (request.rejections) {
+                request.rejections.forEach(rejection => {
+                    const failed = rejection(result);
+
+                    if (failed) {
+                        if (!request.errs) {
+                            request.errs = [];
+                        }
+                        request.errs.push(failed);
+                    }
+                })
+            }
+
+            if (n === this.requests.length - 1) {
+                //If this is the last request settle the promise
+                if (request.errs) {
+                    throw request.errs;
+                } else {
+                    return result;
+                }
+            } else {
+                return handleRequest(n + 1);
+            }
+        }
+
+        return handleRequest(0);
+    }
+
+    then(callbackSuccess, callbackError) {
+        return this.end().then(callbackSuccess, errors => callbackError && callbackError(getFirstError(errors)));
+    }
+
+    catch(callbackError) {
+        return this.end().catch(errors => callbackError && callbackError(getFirstError(errors)));
+    }
 };
 
 function getFirstError(any) {
-    var error = Array.isArray(any) ? any[0] : any;
+    let error = Array.isArray(any) ? any[0] : any;
 
     if (!(error instanceof Error)) {
         error = new Error(error);

--- a/test/hapiTestSpec.js
+++ b/test/hapiTestSpec.js
@@ -1,17 +1,17 @@
 var assert = require('chai').assert,
     hapiTest = require('../index.js'),
-    Hapi = require('hapi'),
-    Boom = require('boom'),
+    Hapi = require('@hapi/hapi'),
+    Boom = require('@hapi/boom'),
     _ = require('lodash');
 
-describe('hapi-test', function() {
+describe('hapi-test', function () {
 
     describe('All verbs are supported', function () {
 
         //simple plugin with all supported verbs
         const plugin = {
             name: 'test',
-            register: function(plugin, options) {
+            register: function (plugin, options) {
                 plugin.route([{
                     method: '*',
                     path: '/',
@@ -21,52 +21,52 @@ describe('hapi-test', function() {
         };
 
 
-        it('should support GET', function() {
+        it('should support GET', function () {
             return hapiTest({
-                    plugins: [plugin]
-                })
+                plugins: [plugin]
+            })
                 .get('/')
                 .assert(200);
         });
 
-        it('should support POST', function() {
+        it('should support POST', function () {
             return hapiTest({
-                    plugins: [plugin]
-                })
+                plugins: [plugin]
+            })
                 .post('/', {})
                 .assert(200);
         });
 
-        it('should support PUT', function() {
+        it('should support PUT', function () {
             return hapiTest({
-                    plugins: [plugin]
-                })
+                plugins: [plugin]
+            })
                 .put('/', {})
                 .assert(200);
         });
 
-        it('should support PATCH', function() {
+        it('should support PATCH', function () {
             return hapiTest({
-                    plugins: [plugin]
-                })
+                plugins: [plugin]
+            })
                 .patch('/', {})
                 .assert(200);
         });
 
-        it('should support DELETE', function() {
+        it('should support DELETE', function () {
             return hapiTest({
-                    plugins: [plugin]
-                })
+                plugins: [plugin]
+            })
                 .delete('/')
                 .assert(200);
         })
     });
 
-    describe('assertions', function() {
+    describe('assertions', function () {
 
         const plugin = {
             name: 'test',
-            register: function(plugin, options) {
+            register: function (plugin, options) {
 
                 plugin.route([{
                     method: 'GET',
@@ -76,46 +76,46 @@ describe('hapi-test', function() {
             }
         };
 
-        it('assert a number should check the status code', function() {
+        it('assert a number should check the status code', function () {
             return hapiTest({
-                    plugins: [plugin]
-                })
+                plugins: [plugin]
+            })
                 .get('/one')
                 .assert(200);
         });
 
-        it('should pass assertion errors to the end method', async function() {
+        it('should pass assertion errors to the end method', async function () {
             try {
                 await hapiTest({ plugins: [plugin] })
                     .get('/one')
                     .assert(1000)
                     .end()
-            } catch(errs) {
+            } catch (errs) {
                 assert(errs);
                 assert.equal(errs[0], 'the status code is: 200 but should be: 1000');
             }
         });
 
-        it('should allow passing in an assertion function', function() {
+        it('should allow passing in an assertion function', function () {
             return hapiTest({ plugins: [plugin] })
                 .get('/one')
-                .assert(function(res) {
+                .assert(function (res) {
                     return res.statusCode === 200;
                 });
         });
 
-        it('if called with 2 strings: match headers[string1] with string2 ', function() {
+        it('if called with 2 strings: match headers[string1] with string2 ', function () {
             return hapiTest({ plugins: [plugin] })
                 .get('/one')
                 .assert('connection', 'keep-alive');
         });
 
-        it('convert string to regex when called with 2 strings', function() {
+        it('convert string to regex when called with 2 strings', function () {
             return hapiTest({ plugins: [plugin] })
                 .get('/one')
                 .assert('connection', 'keep');
         });
-        it('should supply get response to end handler', async function() {
+        it('should supply get response to end handler', async function () {
             const res = await hapiTest({ plugins: [plugin] })
                 .get('/one')
                 .end();
@@ -125,11 +125,11 @@ describe('hapi-test', function() {
         });
     });
 
-    describe('plugins', function() {
-        it('should support multiple plugins', function() {
+    describe('plugins', function () {
+        it('should support multiple plugins', function () {
             const plugin1 = {
                 name: 'testPlugin1',
-                register: function(plugin, options) {
+                register: function (plugin, options) {
 
                     plugin.route([{
                         method: 'GET',
@@ -141,7 +141,7 @@ describe('hapi-test', function() {
 
             const plugin2 = {
                 name: 'testPlugin2',
-                register: function(plugin, options) {
+                register: function (plugin, options) {
 
                     plugin.route([{
                         method: 'GET',
@@ -159,11 +159,11 @@ describe('hapi-test', function() {
         })
     });
 
-    describe('construction with a server object', function() {
+    describe('construction with a server object', function () {
 
         var server;
 
-        before(function() {
+        before(function () {
 
             server = new Hapi.Server({
                 port: 8888
@@ -172,7 +172,7 @@ describe('hapi-test', function() {
             const plugin = {
                 name: 'plugin',
                 version: '0.0.1',
-                register: function(plugin, options) {
+                register: function (plugin, options) {
                     plugin.route([{
                         method: '*',
                         path: '/',
@@ -181,34 +181,34 @@ describe('hapi-test', function() {
                 }
             };
 
-            return server.register({plugin});
+            return server.register({ plugin });
         })
 
-        it('should support GET', function() {
+        it('should support GET', function () {
             return hapiTest({ server: server })
                 .get('/')
                 .assert(200);
         });
 
-        it('should support POST', function() {
+        it('should support POST', function () {
             return hapiTest({ server: server })
                 .post('/', {})
                 .assert(200);
         });
 
-        it('should support PUT', function() {
+        it('should support PUT', function () {
             return hapiTest({ server: server })
                 .put('/', {})
                 .assert(200);
         });
 
-        it('should support PATCH', function() {
+        it('should support PATCH', function () {
             return hapiTest({ server: server })
                 .patch('/', {})
                 .assert(200);
         });
 
-        it('should support DELETE', function() {
+        it('should support DELETE', function () {
             return hapiTest({ server: server })
                 .delete('/')
                 .assert(200);
@@ -217,10 +217,10 @@ describe('hapi-test', function() {
 
     });
 
-    it('should trigger queued requests', async function() {
+    it('should trigger queued requests', async function () {
         const plugin = {
             name: 'test',
-            register: function(plugin, options) {
+            register: function (plugin, options) {
 
                 var persons = [];
 
@@ -240,9 +240,9 @@ describe('hapi-test', function() {
         };
 
         var max = {
-                name: 'Max',
-                _id: 1
-            },
+            name: 'Max',
+            _id: 1
+        },
             lui = {
                 name: 'Lui',
                 _id: 2
@@ -258,10 +258,10 @@ describe('hapi-test', function() {
         assert.deepEqual([max, lui], res.result);
     });
 
-    describe('hapi-auth-cookie', function() {
+    describe('hapi-auth-cookie', function () {
         const plugin = {
             name: 'test',
-            register: function(plugin, options) {
+            register: function (plugin, options) {
 
                 plugin.route([{
                     method: 'GET',
@@ -275,22 +275,24 @@ describe('hapi-test', function() {
         };
 
         //function to setup auth on the server
-        const before = async function(server) {
-            await server.register(require('hapi-auth-cookie'))
+        const before = async function (server) {
+            await server.register(require('@hapi/cookie'))
 
             server.auth.strategy('session', 'cookie', {
-                password: 'secret',
-                cookie: 'session',
+                cookie: {
+                    name: 'session',
+                    password: 'hapi-test-insecure-password',
+                    isSecure: false
+                },
                 redirectTo: '/login',
-                isSecure: false
             });
         };
 
-        it('should bypass authentication with credentials given to auth', async function() {
+        it('should bypass authentication with credentials given to auth', async function () {
             const user = { name: 'max', age: 8 };
 
             const res = await hapiTest({ plugins: [plugin], before })
-                .auth(user)
+                .auth({ credentials: user, strategy: 'session' })
                 .get('/user')
                 .assert(200)
                 .end();
@@ -303,11 +305,11 @@ describe('hapi-test', function() {
 
     });
 
-    describe('request headers', function(){
-        const customHeader = {'special-header':'special-value'};
+    describe('request headers', function () {
+        const customHeader = { 'special-header': 'special-value' };
         const plugin = {
             name: 'test',
-            register: function(plugin, options) {
+            register: function (plugin, options) {
                 plugin.route([{
                     method: 'GET',
                     path: '/specialUrl',
@@ -316,14 +318,14 @@ describe('hapi-test', function() {
             }
         };
 
-        it('should pass given request headers to hapi server inject', function() {
+        it('should pass given request headers to hapi server inject', function () {
             return hapiTest({ plugins: [plugin] })
                 .get('/specialUrl')
                 .setRequestHeader(customHeader)
                 .assert(200);
         });
 
-        it('should give bad request when headers not given', function() {
+        it('should give bad request when headers not given', function () {
             return hapiTest({ plugins: [plugin] })
                 .get('/specialUrl')
                 .assert(400);


### PR DESCRIPTION
The changes were somewhat minor but the conversion to an ES6 class makes this pull-request more noisy than it should have been.

The main breaking change is the structure of the options passed to the `auth` function. This breaking change is needed due to breaking changes introduced to `server.inject` in [Hapi v18](https://github.com/hapijs/hapi/issues/3871).