### PR TITLE
Fix bug with assertions when using thenables

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-test",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Test hapi plugins with chaining method calls and assertions",
   "main": "index.js",
   "repository": {

--- a/src/hapiTest.js
+++ b/src/hapiTest.js
@@ -151,7 +151,10 @@ class HapiTest {
     }
 
     then(callbackSuccess, callbackError) {
-        return this.end().then(callbackSuccess, errors => callbackError && callbackError(getFirstError(errors)));
+        return this.end().then(callbackSuccess, errors => callbackError
+            ? callbackError(getFirstError(errors))
+            : Promise.reject(getFirstError(errors))
+        );
     }
 
     catch(callbackError) {

--- a/test/hapiTestSpec.js
+++ b/test/hapiTestSpec.js
@@ -84,6 +84,20 @@ describe('hapi-test', function () {
                 .assert(200);
         });
 
+        it('should reject when using assertions with thenables', async function () {
+            try {
+                await hapiTest({
+                    plugins: [plugin]
+                })
+                    .get('/one')
+                    .assert(1000)
+                    .then(() => {});
+                throw new Error('Promise was resolved when a rejection was expected');
+            } catch (err) {
+                assert.equal(err.message, 'the status code is: 200 but should be: 1000');
+            }
+        });
+
         it('should pass assertion errors to the end method', async function () {
             try {
                 await hapiTest({ plugins: [plugin] })


### PR DESCRIPTION
This should fix an error that made the assertion not throw an error when calling `.then()` without a `catch` function.